### PR TITLE
support inplace test coverage report

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,34 @@ plugins:
     page_path: dev/reports/coverage
 ```
 
+If the page doesn't exist, it will be created. If the page exists, the coverage report will be appended at the end.
+You can choose *where* to insert the coverage report in the page thanks to the `placeholder` setting:
+
+```yaml
+# mkdocs.yml
+nav:
+- Coverage report: dev/coverage.md  # existing page
+
+plugins:
+- coverage:
+    page_path: dev/coverage
+    placeholder: "[INSERT REPORT HERE]"
+```
+
+In your page:
+
+```md
+# Some page
+
+Some text.
+
+## Coverage report
+
+[INSERT REPORT HERE]
+```
+
+The plugin will replace any such string with the coverage report. **The default placeholder is `<!-- mkdocs-coverage -->`**.
+
 Now serve your documentation,
 and go to http://localhost:8000/coverage/
 to see your coverage report!

--- a/duties.py
+++ b/duties.py
@@ -54,7 +54,7 @@ def changelog(ctx: Context, bump: str = "") -> None:
 
 
 @duty(pre=["check_quality", "check_types", "check_docs", "check_dependencies", "check-api"])
-def check(ctx: Context) -> None:  # noqa: ARG001
+def check(ctx: Context) -> None:
     """Check it all!"""
 
 

--- a/duties.py
+++ b/duties.py
@@ -182,7 +182,7 @@ def coverage(ctx: Context) -> None:
 
 
 @duty
-def test(ctx: Context, *cli_args: str, match: str = "") -> None:
+def test(ctx: Context, *cli_args: str, match: str = "") -> None:  # noqa: PT028
     """Run the test suite.
 
     Parameters:

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -108,7 +108,7 @@ plugins:
 - mkdocstrings:
     handlers:
       python:
-        import:
+        inventories:
         - https://docs.python.org/3/objects.inv
         paths: [src]
         options:

--- a/scripts/make
+++ b/scripts/make
@@ -9,7 +9,7 @@ from contextlib import contextmanager
 from pathlib import Path
 from typing import Any, Iterator
 
-PYTHON_VERSIONS = os.getenv("PYTHON_VERSIONS", "3.8 3.9 3.10 3.11 3.12 3.13").split()
+PYTHON_VERSIONS = os.getenv("PYTHON_VERSIONS", "3.9 3.10 3.11 3.12 3.13").split()
 
 exe = ""
 prefix = ""

--- a/src/mkdocs_coverage/plugin.py
+++ b/src/mkdocs_coverage/plugin.py
@@ -32,7 +32,7 @@ class MkDocsCoverageConfig(Config):
     )
     page_path = MkType(str, default="coverage")
     html_report_dir = MkType(str, default="htmlcov")
-    coverage_inplace_placeholder = MkType(str, default="{{mkdocs-coverage}}")
+    coverage_inplace_placeholder = MkType(str, default="<!-- mkdocs-coverage -->")
 
 
 class MkDocsCoveragePlugin(BasePlugin[MkDocsCoverageConfig]):

--- a/src/mkdocs_coverage/plugin.py
+++ b/src/mkdocs_coverage/plugin.py
@@ -24,7 +24,12 @@ log = get_plugin_logger(__name__)
 class MkDocsCoverageConfig(Config):
     """Configuration options for the plugin."""
 
-    page_name = MkDeprecated(moved_to="page_path", option_type=MkOptional(MkType(str, default=None)))
+    page_name = MkDeprecated(
+        moved_to="page_path",
+        option_type=MkOptional(MkType(str, default=None)),
+        message="The 'page_name' configuration option is deprecated and will be removed in a future release. "
+                "Use the 'page_path' configuration option instead."
+    )
     page_path = MkType(str, default="coverage")
     html_report_dir = MkType(str, default="htmlcov")
     coverage_inplace_placeholder = MkType(str, default="{{mkdocs-coverage}}")
@@ -32,11 +37,6 @@ class MkDocsCoverageConfig(Config):
 
 class MkDocsCoveragePlugin(BasePlugin[MkDocsCoverageConfig]):
     """The MkDocs plugin to integrate the coverage HTML report in the site."""
-
-    def __init__(self) -> None:
-        """Initialize the plugin."""
-        super().__init__()
-        self.page_path: str = ""
 
     def on_files(self, files: Files, config: MkDocsConfig, **kwargs: Any) -> Files:  # noqa: ARG002
         """Add the coverage page to the navigation.
@@ -52,13 +52,12 @@ class MkDocsCoveragePlugin(BasePlugin[MkDocsCoverageConfig]):
         Returns:
             The modified files collection.
         """
-        self.page_path = self.config.page_path if self.config.page_name is None else self.config.page_name
-        covindex = "covindex.html" if config.use_directory_urls else f"{self.page_path}/covindex.html"
-        original_coverage_file = files.get_file_from_path(self.page_path + ".md")
+        covindex = "covindex.html" if config.use_directory_urls else f"{self.config.page_path}/covindex.html"
+        original_coverage_file = files.get_file_from_path(self.config.page_path + ".md")
         original_coverage_file_content = original_coverage_file.content_string if original_coverage_file else None
 
         page_content = self._build_coverage_page(covindex, original_coverage_file_content)
-        file = File.generated(config=config, src_uri=self.page_path + ".md", content=page_content)
+        file = File.generated(config=config, src_uri=self.config.page_path + ".md", content=page_content)
         if file.src_uri in files:
             files.remove(file)
         files.append(file)
@@ -117,7 +116,7 @@ class MkDocsCoveragePlugin(BasePlugin[MkDocsCoverageConfig]):
                 """,
             )
             return style + coverage_page_content
-        if page_content.__contains__(self.config.coverage_inplace_placeholder):
+        if self.config.coverage_inplace_placeholder in page_content:
             return page_content.replace(self.config.coverage_inplace_placeholder, coverage_page_content)
         return page_content + "\n\n" + coverage_page_content
 
@@ -134,7 +133,7 @@ class MkDocsCoveragePlugin(BasePlugin[MkDocsCoverageConfig]):
             **kwargs: Additional arguments passed by MkDocs.
         """
         site_dir = Path(config.site_dir)
-        coverage_dir = site_dir / self.page_path
+        coverage_dir = site_dir / self.config.page_path
         tmp_index = site_dir / ".coverage-tmp.html"
 
         if config.use_directory_urls:

--- a/src/mkdocs_coverage/plugin.py
+++ b/src/mkdocs_coverage/plugin.py
@@ -9,7 +9,9 @@ from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
 from mkdocs.config.base import Config
-from mkdocs.config.config_options import Deprecated as MkDeprecated, Optional as MkOptional, Type as MkType
+from mkdocs.config.config_options import Deprecated as MkDeprecated
+from mkdocs.config.config_options import Optional as MkOptional
+from mkdocs.config.config_options import Type as MkType
 from mkdocs.plugins import BasePlugin
 from mkdocs.structure.files import File, Files
 
@@ -28,7 +30,7 @@ class MkDocsCoverageConfig(Config):
         moved_to="page_path",
         option_type=MkOptional(MkType(str, default=None)),
         message="The 'page_name' configuration option is deprecated and will be removed in a future release. "
-                "Use the 'page_path' configuration option instead."
+        "Use the 'page_path' configuration option instead.",
     )
     page_path = MkType(str, default="coverage")
     html_report_dir = MkType(str, default="htmlcov")

--- a/src/mkdocs_coverage/plugin.py
+++ b/src/mkdocs_coverage/plugin.py
@@ -32,7 +32,7 @@ class MkDocsCoverageConfig(Config):
     )
     page_path = MkType(str, default="coverage")
     html_report_dir = MkType(str, default="htmlcov")
-    coverage_inplace_placeholder = MkType(str, default="<!-- mkdocs-coverage -->")
+    placeholder = MkType(str, default="<!-- mkdocs-coverage -->")
 
 
 class MkDocsCoveragePlugin(BasePlugin[MkDocsCoverageConfig]):
@@ -116,8 +116,8 @@ class MkDocsCoveragePlugin(BasePlugin[MkDocsCoverageConfig]):
                 """,
             )
             return style + coverage_page_content
-        if self.config.coverage_inplace_placeholder in page_content:
-            return page_content.replace(self.config.coverage_inplace_placeholder, coverage_page_content)
+        if self.config.placeholder in page_content:
+            return page_content.replace(self.config.placeholder, coverage_page_content)
         return page_content + "\n\n" + coverage_page_content
 
     def on_post_build(self, config: MkDocsConfig, **kwargs: Any) -> None:  # noqa: ARG002


### PR DESCRIPTION
Add more flexibility to manipulate and positioning the coverage report.

Changes:

- option to hide page title
- possibility to chose where to add the coverage page content:
    Instead of overwriting a possible existing coverage markdown page, check if the page already exists.
    If not, just add the "new" coverage page as before.
    If the page already exists, check for the placeholder `{{mkdocs-coverage}}` and add the coverage page content there, or if the placeholder does not exists add the coverage page content at the end of the existing page.